### PR TITLE
Changed model.insert to skip fields set as undefined #1

### DIFF
--- a/lib/quell.js
+++ b/lib/quell.js
@@ -495,8 +495,8 @@ var Record = {
 			for (;i < c;i++) {
 				field = fields[i];
 				type = self.schema.columns[field];
-
-				if (type && (options.replace || self.schema.autoincrement !== field)) {
+				
+				if (type && self.data[field] !== undefined && (options.replace || self.schema.autoincrement !== field)) {
 					write[field] = type.prepare(self.data[field]);
 				}
 			}


### PR DESCRIPTION
Optional (potentially incomplete) solution to make insert queries skip fields which have been set as undefined.

Probably needs a test.

Awesome project by the way - just changed over from Sequelize. Much friendlier.
